### PR TITLE
Remove leftover prop

### DIFF
--- a/src/components/ConfirmPublish.js
+++ b/src/components/ConfirmPublish.js
@@ -48,7 +48,6 @@ class ConfirmPublish extends Component {
 				<Fragment>
 					<PostPublishButton
 						focusOnMount={ true }
-						onSubmit={ this.onSubmit }
 						forceIsDirty={ forceIsDirty }
 						forceIsSaving={ forceIsSaving }
 					/>


### PR DESCRIPTION
I believe the `onSubmit` prop is a leftover from the oiginal implementation in the `PostPublishPanel` component in Gutenberg.

In the `ConfirmPublish` component in this repository, there is no `onSubmit` method, meaning it is `undefined` and thus defaulting to `noop` as per `PostPublishButton`. So I removed it.

Does that make sense, @rmccue?