### PR TITLE
Fixed warning

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -279,6 +279,10 @@ function get_merged_meta( int $id, array $meta ) : array {
 
 	// Fetch existing meta.
 	$existing_meta = get_post_meta( $id );
+	if ( ! is_array( $existing_meta ) ) {
+		$existing_meta = [];
+	}
+
 	foreach ( $existing_meta as $key => $values ) {
 		$options = $registered[ $key ] ?? null;
 		$single = $options && $options['single'];


### PR DESCRIPTION
When retrieving a post meta list and the post did not exist, the following loop was throwing a warning

See #13