### PR TITLE
Ensure assets only load when block editor is in use

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -56,10 +56,8 @@ function should_block_publish() {
  * Enqueue browser assets for the editor.
  */
 function enqueue_assets() {
-	global $pagenow;
-
-	// Ensure this is an edit post page.
-	if ( empty( $pagenow ) || ! in_array( $pagenow, [ 'post.php', 'post-new.php' ], true ) ) {
+	// Ensure this screen is using the block editor.
+	if ( ! wp_script_is( 'wp-block-editor', 'enqueued' ) ) {
 		return;
 	}
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -56,6 +56,13 @@ function should_block_publish() {
  * Enqueue browser assets for the editor.
  */
 function enqueue_assets() {
+	global $pagenow;
+
+	// Ensure this is an edit post page.
+	if ( empty( $pagenow ) || ! in_array( $pagenow, [ 'post.php', 'post-new.php' ], true ) ) {
+		return;
+	}
+
 	wp_enqueue_script(
 		SCRIPT_ID,
 		plugins_url( 'build/index.js', __DIR__ ),


### PR DESCRIPTION
The `wp_enqueue_editor` hook can run anywhere the block editor or classic editor is loaded. This can cause compatibility issues with other plugins such as Yoast SEO as it causes `wp-edit-post` to load on pages such as the term edit screen.

I had opened this issue on the Yoast SEO GitHub before I traced the root of the problem: https://github.com/Yoast/wordpress-seo/issues/15822

I _think_ that the JS in that plugin changes some behaviour if the `edit-post` script is present as checks for the associated data store existing eg. `wp.data.select('core/edit-post')`