### PR TITLE
Check post exists before trying to reference it.

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -464,7 +464,7 @@ function block_publish_if_failing( array $data, array $postarr ) : array {
 	if ( isset( $postarr['ID'] ) ) {
 		$existing = get_post( $postarr['ID'], ARRAY_A );
 
-		if ( isset( $existing['post_status'] ) && $existing['post_status'] === $data['post_status'] ) {
+		if ( ! empty( $existing ) && isset( $existing['post_status'] ) && $existing['post_status'] === $data['post_status'] ) {
 			return $data;
 		}
 	}


### PR DESCRIPTION
Fixes issue https://github.com/humanmade/publication-checklist/issues/24 - unit testes failures.

Function `block_publish_if_failing` is hooked to filter `wp_insert_post_data`. This filter can fire _before_ a post is created.
The function assumes its call to `get_post()` will always work.

Related to issue https://github.com/humanmade/vantage-backend/issues/1528
