### PR TITLE
Add lodash to dependencies

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -68,6 +68,7 @@ function enqueue_assets() {
 			'wp-block-editor',
 			'wp-edit-post',
 			'wp-plugins',
+			'lodash',
 		]
 	);
 	wp_enqueue_style(


### PR DESCRIPTION
In WordPress 6.4 and later lodash is no longer guaranteed to be available by default on post edit screens so must be added to the dependencies list here.