### PR TITLE
Fix NULL data ID value fatal error on WordPress 6.6

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -215,9 +215,12 @@ function register_prepublish_check( $id, $options ) {
 function get_check_status_for_api( array $data ) : ?stdClass {
 	/** @var array */
 	$post = get_post( $data['id'], ARRAY_A );
-	if ( empty( $post ) ) {
+
+	// Bail early if post or data ID is empty
+	if ( empty( $post ) || empty( $data['id'] ) ) {
 		return null;
 	}
+
 	$meta = get_post_meta( $data['id'] );
 	$terms = get_post_terms( $data['id'] );
 


### PR DESCRIPTION
In the latest WordPress version, creating a post returns a FATAL error due to the data ID value being NULL. This PR fixes this issue. Thanks!

<img width="873" alt="Screenshot 2024-07-19 at 2 11 38 AM" src="https://github.com/user-attachments/assets/7291bf83-6ce7-4fe1-9e37-5fdba2a711b1">

cc @roborourke @jerico 
