### PR TITLE
Fix: Undefined array key "id"

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -213,16 +213,23 @@ function register_prepublish_check( $id, $options ) {
  * @return stdClass Map of check ID => status.
  */
 function get_check_status_for_api( array $data ) : ?stdClass {
-	/** @var array */
-	$post = get_post( $data['id'], ARRAY_A );
+	$id = $data['id'] ?? null;
 
-	// Bail early if post or data ID is empty
-	if ( empty( $post ) || empty( $data['id'] ) ) {
+	// Bail early if no ID is set.
+	if ( ! isset( $id ) ) {
 		return null;
 	}
 
-	$meta = get_post_meta( $data['id'] );
-	$terms = get_post_terms( $data['id'] );
+	/** @var array */
+	$post = get_post( $id, ARRAY_A );
+
+	// Bail early if post or data ID is empty
+	if ( empty( $post ) ) {
+		return null;
+	}
+
+	$meta = get_post_meta( $id );
+	$terms = get_post_terms( $id );
 
 	$statuses = get_check_status( $post, $meta, $terms );
 	$status_data = [];


### PR DESCRIPTION
Added a null check for `$data['id']` at the start of the `get_check_status_for_api` function to ensure the function returns early if not set. Fixing a Warning ErrorException.