### PR TITLE
Bail out even earlier if data['id'] is empty to avoid undefined key warning

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -213,11 +213,16 @@ function register_prepublish_check( $id, $options ) {
  * @return stdClass Map of check ID => status.
  */
 function get_check_status_for_api( array $data ) : ?stdClass {
+	// Bail early if data ID is empty
+	if ( empty( $data['id'] ) ) {
+		return null;
+	}
+
 	/** @var array */
 	$post = get_post( $data['id'], ARRAY_A );
 
-	// Bail early if post or data ID is empty
-	if ( empty( $post ) || empty( $data['id'] ) ) {
+	// Bail early if post is empty
+	if ( empty( $post ) ) {
 		return null;
 	}
 


### PR DESCRIPTION
Follow-on to #30 

This avoids a scenario where an undefined key warning is raised when requesting `get_post( $data['id'] )` if `$data['id']` is empty.