### PR TITLE
Check the global flag for blocking publish status

### DIFF
--- a/src/components/ChecklistPanelContent.js
+++ b/src/components/ChecklistPanelContent.js
@@ -12,17 +12,19 @@ import ConfirmOverrideHelpText from './ConfirmOverrideHelpText';
 
 import { itemsCollectionPropType } from '../propTypes';
 
+
 const ChecklistPanelContent = ( {
 	baseClassName,
 	completableItems,
 	completed,
 	otherItems,
-	shouldBlockPublish,
 	toComplete,
 	onConfirmedReady,
 } ) => {
 	const [ isExpanded, setExpanded ] = useState( false );
 	const [ confirmedReady, setConfirmedReady ] = useState( false );
+
+	const shouldBlockPublish = !! window.altisPublicationChecklist.block_publish ?? false;
 
 	useEffect( () => {
 		onConfirmedReady( completed >= toComplete || confirmedReady );


### PR DESCRIPTION
The ChecklistPanelContent component was expecting a prop flagging whether or not the checklist should block publish, but this attribute was removed when moving the locking state to the toolbar icon.

This PR updates the component to fetch the `shouldBlockPublish` flag from the plugin global instead, as it should be being retrieved.