### PR TITLE
Fix styling of icon in publication checklist dropdown

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -85,11 +85,18 @@
 		&--to-complete .components-panel__body-title .components-button {
 			--indicator-size: 0.8em;
 
+			align-items: center;
 			position: relative;
+
+			svg {
+				fill: #f97a14;
+				height: 30px;
+				margin-left: auto;
+				width: 30px;
+			}
 
 			&::before {
 				content: '';
-				display: inline-block;
 				width: calc( var( --indicator-size ) + 0.5em );
 			}
 
@@ -107,6 +114,10 @@
 
 		&--completed .components-panel__body-title .components-button::after {
 			background: #3fcf8e;
+		}
+
+		&--completed .components-panel__body-title .components-button svg {
+			fill: #3fcf8e;
 		}
 	}
 }


### PR DESCRIPTION
This styling was somehow left broken after updating the save lock icon in #34. Fixing it here as a basic quality of life improvement.