### PR TITLE
i18n: Use positional placeholders for task labels

### DIFF
--- a/src/components/CompletionIndicator.js
+++ b/src/components/CompletionIndicator.js
@@ -10,9 +10,17 @@ const CompletionIndicator = ( { baseClassName, completed, toComplete } ) => {
 		return null;
 	}
 
-	/* translators: %s: number of completed tasks, %s: total number of to-complete tasks */
 	const label = sprintf(
-		_n( '%s of %s task completed.', '%s of %s tasks completed.', toComplete, 'altis-publication-checklist' ),
+		/* 
+		 * translators: 1: number of completed tasks,
+		 * 2: total number of tasks to complete
+		 */
+		_n(
+			'%1$s of %2$s task completed.', 
+			'%1$s of %2$s tasks completed.', 
+			toComplete, 
+			'altis-publication-checklist' 
+		),
 		completed,
 		toComplete,
 	);


### PR DESCRIPTION
Refactor task completion strings to use positional placeholders (%1$s, %2$s) and multi-line translator comments.

This ensures:
- Translators can reorder variables for correct grammar in other languages.
- Contextual information is clearly provided for extraction tools.